### PR TITLE
Fix: Use `module.this.id` Instead of `module.this.name`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,8 +15,8 @@
 
 # Cloud Posse must review any changes to standard context definition,
 # but some changes can be rubber-stamped.
-**/*.tf       @cloudposse/engineering @cloudposse/approvers
-README.yaml   @cloudposse/engineering @cloudposse/approvers
+**/*.tf       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+README.yaml   @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 README.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 docs/*.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,6 +17,7 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
+    - 'no-release'
   default: 'minor'
 
 categories:
@@ -46,7 +47,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/---\s+^#.*Renovate configuration(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -56,3 +56,10 @@ pull_request_rules:
       changes_requested: true
       approved: true
       message: "This Pull Request has been updated, so we're dismissing all reviews."
+
+- name: "close Pull Requests without files changed"
+  conditions:
+    - "#files=0"
+  actions:
+    close:
+      message: "This pull request has been automatically closed by Mergify because there are no longer any changes."

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   auto-format:
     runs-on: ubuntu-latest
-    container: cloudposse/build-harness:slim-latest
+    container: cloudposse/build-harness:latest
     steps:
     # Checkout the pull request branch
     #  "An action in a workflow run can’t trigger a new workflow run. For example, if an action pushes code using
@@ -29,6 +29,8 @@ jobs:
     - name: Auto Format
       if: github.event.pull_request.state == 'open'
       shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
       run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
 
     # Commit changes (if any) to the PR branch

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,17 +3,24 @@ name: auto-release
 on:
   push:
     branches:
-    - master
+      - main
+      - master
+      - production
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-    # Drafts your next Release notes as Pull Requests are merged into "master"
-    - uses: release-drafter/release-drafter@v5
-      with:
-        publish: true
-        prerelease: false
-        config-name: auto-release.yml
-      env:
-        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+      # Get PR from merged commit to master
+      - uses: actions-ecosystem/action-get-merged-pull-request@v1
+        id: get-merged-pull-request
+        with:
+          github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+      # Drafts your next Release notes as Pull Requests are merged into "main"
+      - uses: release-drafter/release-drafter@v5
+        with:
+          publish: ${{ !contains(steps.get-merged-pull-request.outputs.labels, 'no-release') }}
+          prerelease: false
+          config-name: auto-release.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,5 +1,7 @@
 name: Validate Codeowners
 on:
+  workflow_dispatch:
+
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -403,12 +403,14 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 ### Contributors
 
 <!-- markdownlint-disable -->
-|  [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] |
-|---|
+|  [![Yonatan Koren][korenyoni_avatar]][korenyoni_homepage]<br/>[Yonatan Koren][korenyoni_homepage] | [![RB][nitrocode_avatar]][nitrocode_homepage]<br/>[RB][nitrocode_homepage] |
+|---|---|
 <!-- markdownlint-restore -->
 
   [korenyoni_homepage]: https://github.com/korenyoni
   [korenyoni_avatar]: https://img.cloudposse.com/150x150/https://github.com/korenyoni.png
+  [nitrocode_homepage]: https://github.com/nitrocode
+  [nitrocode_avatar]: https://img.cloudposse.com/150x150/https://github.com/nitrocode.png
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2020-2021 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2020-2022 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -120,3 +120,5 @@ include:
 contributors:
   - name: "Yonatan Koren"
     github: "korenyoni"
+  - name: "RB"
+    github: "nitrocode"

--- a/asm.tf
+++ b/asm.tf
@@ -1,7 +1,7 @@
 resource "aws_secretsmanager_secret" "certificate" {
   count = local.asm_enabled ? 1 : 0
 
-  name                    = format(var.secret_path_format, module.this.name, var.secret_extensions.certificate)
+  name                    = format(var.secret_path_format, module.this.id, var.secret_extensions.certificate)
   recovery_window_in_days = var.asm_recovery_window_in_days
   kms_key_id              = local.certificate_backend_kms_key_id
 
@@ -18,7 +18,7 @@ resource "aws_secretsmanager_secret_version" "certificate" {
 resource "aws_secretsmanager_secret" "private_key" {
   count = local.asm_enabled ? 1 : 0
 
-  name                    = format(var.secret_path_format, module.this.name, var.secret_extensions.private_key)
+  name                    = format(var.secret_path_format, module.this.id, var.secret_extensions.private_key)
   recovery_window_in_days = var.asm_recovery_window_in_days
   kms_key_id              = local.certificate_backend_kms_key_id
 

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,6 @@ resource "tls_private_key" "default" {
   rsa_bits    = var.private_key_algorithm == "RSA" ? var.private_key_rsa_bits : null
 }
 
-
 resource "tls_cert_request" "default" {
   count = local.enabled && var.use_locally_signed ? 1 : 0
 

--- a/ssm.tf
+++ b/ssm.tf
@@ -1,7 +1,7 @@
 resource "aws_ssm_parameter" "certificate" {
   count = local.ssm_enabled ? 1 : 0
 
-  name   = format(var.secret_path_format, module.this.name, var.secret_extensions.certificate)
+  name   = format(var.secret_path_format, module.this.id, var.secret_extensions.certificate)
   type   = "SecureString"
   key_id = local.certificate_backend_kms_key_id
   value  = var.certificate_backends_base64_enabled ? base64encode(local.tls_certificate) : local.tls_certificate
@@ -12,7 +12,7 @@ resource "aws_ssm_parameter" "certificate" {
 resource "aws_ssm_parameter" "private_key" {
   count = local.ssm_enabled ? 1 : 0
 
-  name   = format(var.secret_path_format, module.this.name, var.secret_extensions.private_key)
+  name   = format(var.secret_path_format, module.this.id, var.secret_extensions.private_key)
   type   = "SecureString"
   key_id = local.certificate_backend_kms_key_id
   value  = var.certificate_backends_base64_enabled ? base64encode(local.tls_key) : local.tls_key

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -78,10 +78,10 @@ func testExamplesCompleteNonCA(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-	assert.Equal(t, "/eg-ue1-test-self-signed-cert-" + attributes[0] + ".pem", certificatePEMPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert-"+attributes[0]+".pem", certificatePEMPath)
 
 	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-	assert.Equal(t, "/eg-ue1-test-self-signed-cert-" + attributes[0] + ".key", certificateKeyPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert-"+attributes[0]+".key", certificateKeyPath)
 }
 
 func testExamplesCompleteCA(t *testing.T) {
@@ -112,8 +112,8 @@ func testExamplesCompleteCA(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-	assert.Equal(t, "/eg-ue1-test-self-signed-cert-ca-" + attributes[0] + ".pem", certificatePEMPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert-ca-"+attributes[0]+".pem", certificatePEMPath)
 
 	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-	assert.Equal(t, "/eg-ue1-test-self-signed-cert-ca-" + attributes[0] + ".key", certificateKeyPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert-ca-"+attributes[0]+".key", certificateKeyPath)
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -78,10 +78,10 @@ func testExamplesCompleteNonCA(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-	assert.Equal(t, "/eg-ue1-test-self-signed-cert.pem", certificatePEMPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert" + attributes[0] + ".pem", certificatePEMPath)
 
 	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-	assert.Equal(t, "/eg-ue1-test-self-signed-cert.key", certificateKeyPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert" + attributes[0] + ".key", certificateKeyPath)
 }
 
 func testExamplesCompleteCA(t *testing.T) {
@@ -112,8 +112,8 @@ func testExamplesCompleteCA(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-	assert.Equal(t, "/self-signed-cert-ca.pem", certificatePEMPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert" + attributes[0] + ".pem", certificatePEMPath)
 
 	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-	assert.Equal(t, "/self-signed-cert-ca.key", certificateKeyPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert" + attributes[0] + ".key", certificateKeyPath)
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -78,10 +78,10 @@ func testExamplesCompleteNonCA(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-	assert.Equal(t, "/self-signed-cert.pem", certificatePEMPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert.pem", certificatePEMPath)
 
 	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-	assert.Equal(t, "/self-signed-cert.key", certificateKeyPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert.key", certificateKeyPath)
 }
 
 func testExamplesCompleteCA(t *testing.T) {

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -78,10 +78,10 @@ func testExamplesCompleteNonCA(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-	assert.Equal(t, "/eg-ue1-test-self-signed-cert" + attributes[0] + ".pem", certificatePEMPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert-" + attributes[0] + ".pem", certificatePEMPath)
 
 	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-	assert.Equal(t, "/eg-ue1-test-self-signed-cert" + attributes[0] + ".key", certificateKeyPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert-" + attributes[0] + ".key", certificateKeyPath)
 }
 
 func testExamplesCompleteCA(t *testing.T) {
@@ -112,8 +112,8 @@ func testExamplesCompleteCA(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-	assert.Equal(t, "/eg-ue1-test-self-signed-cert" + attributes[0] + ".pem", certificatePEMPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert-ca-" + attributes[0] + ".pem", certificatePEMPath)
 
 	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-	assert.Equal(t, "/eg-ue1-test-self-signed-cert" + attributes[0] + ".key", certificateKeyPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert-ca-" + attributes[0] + ".key", certificateKeyPath)
 }

--- a/test/src/examples_custom_secrets_test.go
+++ b/test/src/examples_custom_secrets_test.go
@@ -24,8 +24,8 @@ func TestExamplesCustomSecrets(t *testing.T) {
 	t.Run("NoStore", testExamplesCustomSecretsNoStore)
 	t.Run("SSM", testExamplesCustomSecretsSSM)
 	t.Run("ASM", testExamplesCustomSecretsASM)
-  t.Run("CMK", testExamplesCustomSecretsCMK)
-  t.Run("CustomSuffixes", testExamplesCustomSecretsSuffixes)
+	t.Run("CMK", testExamplesCustomSecretsCMK)
+	t.Run("CustomSuffixes", testExamplesCustomSecretsSuffixes)
 }
 
 func testExamplesCustomSecretsNoStore(t *testing.T) {
@@ -84,10 +84,10 @@ func testExamplesCustomSecretsSSM(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-	assert.Equal(t, "/test-ssm/self-signed-cert-ssm.pem", certificatePEMPath)
+	assert.Equal(t, "/test-ssm/eg-ue1-test-self-signed-cert-ssm"+attributes[0]+".pem", certificatePEMPath)
 
 	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-	assert.Equal(t, "/test-ssm/self-signed-cert-ssm.key", certificateKeyPath)
+	assert.Equal(t, "/test-ssm/eg-ue1-test-self-signed-cert-ssm"+attributes[0]+".key", certificateKeyPath)
 }
 
 func testExamplesCustomSecretsASM(t *testing.T) {
@@ -118,77 +118,76 @@ func testExamplesCustomSecretsASM(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-	assert.Equal(t, "/test-asm/self-signed-cert-asm.pem", certificatePEMPath)
+	assert.Equal(t, "/test-asm/eg-ue1-test-self-signed-cert-asm"+attributes[0]+".pem", certificatePEMPath)
 
 	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-	assert.Equal(t, "/test-asm/self-signed-cert-asm.key", certificateKeyPath)
+	assert.Equal(t, "/test-asm/eg-ue1-test-self-signed-cert-asm"+attributes[0]+".key", certificateKeyPath)
 }
 
-
 func testExamplesCustomSecretsCMK(t *testing.T) {
-  t.Parallel()
+	t.Parallel()
 
-  rand.Seed(time.Now().UnixNano() + 3) // give a slightly different seed than the other parallel tests
+	rand.Seed(time.Now().UnixNano() + 3) // give a slightly different seed than the other parallel tests
 
-  attributes := []string{strconv.Itoa(rand.Intn(100000))}
+	attributes := []string{strconv.Itoa(rand.Intn(100000))}
 
-  terraformOptions := &terraform.Options{
-    // The path to where our Terraform code is located
-    TerraformDir: "../../examples/custom_secrets",
-    Upgrade:      true,
-    EnvVars: map[string]string{
-      "TF_CLI_ARGS": "-state=terraform-cmk-test.tfstate",
-    },
-    // Variables to pass to our Terraform code using -var-file options
-    VarFiles: []string{"customer-managed-key.us-east-1.tfvars"},
-    Vars: map[string]interface{}{
-      "attributes": attributes,
-    },
-  }
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../../examples/custom_secrets",
+		Upgrade:      true,
+		EnvVars: map[string]string{
+			"TF_CLI_ARGS": "-state=terraform-cmk-test.tfstate",
+		},
+		// Variables to pass to our Terraform code using -var-file options
+		VarFiles: []string{"customer-managed-key.us-east-1.tfvars"},
+		Vars: map[string]interface{}{
+			"attributes": attributes,
+		},
+	}
 
-  // At the end of the test, run `terraform destroy` to clean up any resources that were created
-  defer terraform.Destroy(t, terraformOptions)
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
 
-  // This will run `terraform init` and `terraform apply` and fail the test if there are any errors
-  terraform.Apply(t, terraformOptions)
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.Apply(t, terraformOptions)
 
-  certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-  assert.Equal(t, "/test-cmk/self-signed-cert-cmk.pem", certificatePEMPath)
+	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
+	assert.Equal(t, "/test-cmk/eg-ue1-test-self-signed-cert-cmk-"+attributes[0]+".pem", certificatePEMPath)
 
-  certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-  assert.Equal(t, "/test-cmk/self-signed-cert-cmk.key", certificateKeyPath)
+	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
+	assert.Equal(t, "/test-cmk/eg-ue1-test-self-signed-cert-cmk-"+attributes[0]+".key", certificateKeyPath)
 }
 
 func testExamplesCustomSecretsSuffixes(t *testing.T) {
-  t.Parallel()
+	t.Parallel()
 
-  rand.Seed(time.Now().UnixNano() + 4) // give a slightly different seed than the other parallel tests
+	rand.Seed(time.Now().UnixNano() + 4) // give a slightly different seed than the other parallel tests
 
-  attributes := []string{strconv.Itoa(rand.Intn(100000))}
+	attributes := []string{strconv.Itoa(rand.Intn(100000))}
 
-  terraformOptions := &terraform.Options{
-    // The path to where our Terraform code is located
-    TerraformDir: "../../examples/custom_secrets",
-    Upgrade:      true,
-    EnvVars: map[string]string{
-      "TF_CLI_ARGS": "-state=terraform-custom-suffixes-test.tfstate",
-    },
-    // Variables to pass to our Terraform code using -var-file options
-    VarFiles: []string{"custom-suffixes.us-east-1.tfvars"},
-    Vars: map[string]interface{}{
-      "attributes": attributes,
-    },
-  }
+	terraformOptions := &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../../examples/custom_secrets",
+		Upgrade:      true,
+		EnvVars: map[string]string{
+			"TF_CLI_ARGS": "-state=terraform-custom-suffixes-test.tfstate",
+		},
+		// Variables to pass to our Terraform code using -var-file options
+		VarFiles: []string{"custom-suffixes.us-east-1.tfvars"},
+		Vars: map[string]interface{}{
+			"attributes": attributes,
+		},
+	}
 
-  // At the end of the test, run `terraform destroy` to clean up any resources that were created
-  defer terraform.Destroy(t, terraformOptions)
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
 
-  // This will run `terraform init` and `terraform apply` and fail the test if there are any errors
-  terraform.Apply(t, terraformOptions)
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.Apply(t, terraformOptions)
 
-  certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-  assert.Equal(t, "/self-signed-cert-custom-suffixes.crt", certificatePEMPath)
+	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert-custom-suffixes"+attributes[0]+".crt", certificatePEMPath)
 
-  certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-  assert.Equal(t, "/self-signed-cert-custom-suffixes.key", certificateKeyPath)
+	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert-custom-suffixes"+attributes[0]+".key", certificateKeyPath)
 }

--- a/test/src/examples_custom_secrets_test.go
+++ b/test/src/examples_custom_secrets_test.go
@@ -84,10 +84,10 @@ func testExamplesCustomSecretsSSM(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-	assert.Equal(t, "/test-ssm/eg-ue1-test-self-signed-cert-ssm"+attributes[0]+".pem", certificatePEMPath)
+	assert.Equal(t, "/test-ssm/eg-ue1-test-self-signed-cert-ssm-"+attributes[0]+".pem", certificatePEMPath)
 
 	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-	assert.Equal(t, "/test-ssm/eg-ue1-test-self-signed-cert-ssm"+attributes[0]+".key", certificateKeyPath)
+	assert.Equal(t, "/test-ssm/eg-ue1-test-self-signed-cert-ssm-"+attributes[0]+".key", certificateKeyPath)
 }
 
 func testExamplesCustomSecretsASM(t *testing.T) {
@@ -118,10 +118,10 @@ func testExamplesCustomSecretsASM(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-	assert.Equal(t, "/test-asm/eg-ue1-test-self-signed-cert-asm"+attributes[0]+".pem", certificatePEMPath)
+	assert.Equal(t, "/test-asm/eg-ue1-test-self-signed-cert-asm-"+attributes[0]+".pem", certificatePEMPath)
 
 	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-	assert.Equal(t, "/test-asm/eg-ue1-test-self-signed-cert-asm"+attributes[0]+".key", certificateKeyPath)
+	assert.Equal(t, "/test-asm/eg-ue1-test-self-signed-cert-asm-"+attributes[0]+".key", certificateKeyPath)
 }
 
 func testExamplesCustomSecretsCMK(t *testing.T) {
@@ -186,8 +186,8 @@ func testExamplesCustomSecretsSuffixes(t *testing.T) {
 	terraform.Apply(t, terraformOptions)
 
 	certificatePEMPath := terraform.Output(t, terraformOptions, "certificate_pem_path")
-	assert.Equal(t, "/eg-ue1-test-self-signed-cert-custom-suffixes"+attributes[0]+".crt", certificatePEMPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert-custom-suffixes-"+attributes[0]+".crt", certificatePEMPath)
 
 	certificateKeyPath := terraform.Output(t, terraformOptions, "certificate_key_path")
-	assert.Equal(t, "/eg-ue1-test-self-signed-cert-custom-suffixes"+attributes[0]+".key", certificateKeyPath)
+	assert.Equal(t, "/eg-ue1-test-self-signed-cert-custom-suffixes-"+attributes[0]+".key", certificateKeyPath)
 }


### PR DESCRIPTION
## what
* Use context id instead of name

## why
* Keep the keys unique

## references
* Could be utilized by https://github.com/cloudposse/terraform-aws-ec2-client-vpn/pull/24

