### PR TITLE
Remove key_algorithm from tls_cert_request

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/README.md
+++ b/README.md
@@ -161,14 +161,14 @@ Available targets:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.4.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.4.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.2.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -161,14 +161,14 @@ Available targets:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.4.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,14 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.4.0 |
 
 ## Modules
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,14 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.4.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.4.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.2.0 |
 
 ## Modules
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 3.4.0"
+      version = ">= 3.2.0"
     }
   }
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 3.0"
+      version = ">= 3.4.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,6 @@ resource "tls_locally_signed_cert" "default" {
   is_ca_certificate = var.basic_constraints.ca
 
   cert_request_pem   = join("", tls_cert_request.default.*.cert_request_pem)
-  ca_key_algorithm   = var.private_key_algorithm
   ca_private_key_pem = var.certificate_chain.private_key_pem
   ca_cert_pem        = var.certificate_chain.cert_pem
 
@@ -58,7 +57,6 @@ resource "tls_self_signed_cert" "default" {
 
   is_ca_certificate = var.basic_constraints.ca
 
-  key_algorithm   = var.private_key_algorithm
   private_key_pem = coalesce(join("", tls_private_key.default.*.private_key_pem), var.private_key_contents)
 
   validity_period_hours = var.validity.duration_hours

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,6 @@ resource "tls_private_key" "default" {
 resource "tls_cert_request" "default" {
   count = local.enabled && var.use_locally_signed ? 1 : 0
 
-  key_algorithm   = var.private_key_algorithm
   private_key_pem = coalesce(join("", tls_private_key.default.*.private_key_pem), var.private_key_contents)
 
   subject {

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 3.4.0"
+      version = ">= 3.2.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 3.0"
+      version = ">= 3.4.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Remove `key_algorithm` from `tls_cert_request`
* Remove `ca_key_algorithm` from `tls_locally_signed_cert`

## why
* Deprecated

## references
* Closes https://github.com/cloudposse/terraform-aws-ssm-tls-self-signed-cert/issues/13
* https://registry.terraform.io/providers/hashicorp/tls/latest/docs
* https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request#key_algorithm

