### PR TITLE
fix: missing arguments at tls_cert_request resource

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ssm-tls-self-signed-cert&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ssm-tls-self-signed-cert&utm_content=website
@@ -445,3 +445,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-ssm-tls-self-signed-cert
   [share_email]: mailto:?subject=terraform-aws-ssm-tls-self-signed-cert&body=https://github.com/cloudposse/terraform-aws-ssm-tls-self-signed-cert
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-ssm-tls-self-signed-cert?pixel&cs=github&cm=readme&an=terraform-aws-ssm-tls-self-signed-cert
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,10 @@ resource "tls_cert_request" "default" {
     postal_code         = lookup(var.subject, "postal_code", null)
     serial_number       = lookup(var.subject, "serial_number", null)
   }
+
+  dns_names    = var.subject_alt_names.dns_names
+  ip_addresses = var.subject_alt_names.ip_addresses
+  uris         = var.subject_alt_names.uris
 }
 
 resource "tls_locally_signed_cert" "default" {


### PR DESCRIPTION
## what
* add missing arguments for dns_name, ip_addresses and uris at tls_cert_request resource 

## why
* must be set for multi domain certificates (https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request)

## references
* [Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). ](https://github.com/cloudposse/terraform-aws-ssm-tls-self-signed-cert/pull/11)

