### PR TITLE
Version Lock 3.X

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -161,14 +161,14 @@ Available targets:
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.2.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.2.0, < 4.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.2.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.2.0, < 4.0.0 |
 
 ## Modules
 
@@ -343,7 +343,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2020-2022 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2020-2023 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 
@@ -414,7 +414,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ssm-tls-self-signed-cert&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-ssm-tls-self-signed-cert&utm_content=website
@@ -445,3 +445,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-ssm-tls-self-signed-cert
   [share_email]: mailto:?subject=terraform-aws-ssm-tls-self-signed-cert&body=https://github.com/cloudposse/terraform-aws-ssm-tls-self-signed-cert
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-ssm-tls-self-signed-cert?pixel&cs=github&cm=readme&an=terraform-aws-ssm-tls-self-signed-cert
+<!-- markdownlint-restore -->

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,14 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.2.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 3.2.0, < 4.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.2.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 3.2.0, < 4.0.0 |
 
 ## Modules
 

--- a/versions.tf
+++ b/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = ">= 3.2.0"
+      version = ">= 3.2.0, < 4.0.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Lock version to 3.X

## why
* Version 4.0 came out with release notes:
> resource/tls_cert_request: Attribute key_algorithm is now read-only, as it's inferred from private_key_pem 

## Note:
This is a bandaid fix, ideally we should upgrade to 4.X, this will take time to upgrade many other components however, since many breaking changes we're introduced I'm proposing a version lock until that time